### PR TITLE
Fix security hole ... do *NOT* open the app port on the outside if the port is only meant for internal reverse-proxy use !

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -36,10 +36,6 @@ if [[ ! $? -eq 0 ]]; then
   exit 1
 fi
 
-# Open port in firewall
-sudo yunohost firewall allow TCP 9981 > /dev/null 2>&1
-sudo yunohost firewall allow TCP 9982 > /dev/null 2>&1
-
 # Add Tvheadend repository
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 379CE192D401AB61
 echo "deb https://dl.bintray.com/tvheadend/deb $DEB_VERSION release" | sudo tee /etc/apt/sources.list.d/tvheadend.list


### PR DESCRIPTION
NB : I haven't checked to be 100% sure it's not needed, feel free to close and ignore if this PR is not relevant. I'm just trying to through all the possible apps with this issue ...

In particular for this app : pretty sure that port 9981 is only for internal use, but i dunno about 9982

Otherwise : 
- this should be fixed ASAP >_>
- I haven't checked other scripts (upgrade, restore, ..?) which may also have this line in where this should be removed
- To properly fix the issue for existing installs, the remove script should be adapted to close that port if it's opened...